### PR TITLE
Fixed a possible NullException

### DIFF
--- a/src/AWSCore.jl
+++ b/src/AWSCore.jl
@@ -189,7 +189,8 @@ function do_request(r::AWSRequest)
     end
 
     # If there is reponse data check for (and parse) XML or JSON...
-    if typeof(response) == Response && length(response.data) > 0
+    if typeof(response) == Response && length(response.data) > 0 &&
+       !isnull(mimetype(response))
 
         mime = get(mimetype(response))
 


### PR DESCRIPTION
I found that the begin multipart upload endpoint did not return a Content-Type header for some reason. I'm not sure if this is a bug in how AWSCore creates the request or a bug with amazon (their response examples don't have Content-Type listed). Anyway in the event that this happens this change makes AWSCore simply return the Response to the caller.