### PR TITLE
Fix up `aws_config` to work on running EC2 instance

### DIFF
--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -76,9 +76,8 @@ function localhost_is_ec2()
     end
 
     @unix_only begin
-        host = readstring(`hostname -f`)
-        return ismatch(r"compute.internal$", host) ||
-               ismatch(r"ec2.internal$", host)
+        return isfile("/sys/hypervisor/uuid") &&
+               readstring(`head -c 3 /sys/hypervisor/uuid`) == "ec2"
     end
 
     return false

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -121,8 +121,6 @@ end
 
 function ec2_metadata(key)
 
-    @assert localhost_is_ec2()
-
     http_request("169.254.169.254", "latest/meta-data/$key").data
 end
 
@@ -132,8 +130,6 @@ end
 using JSON
 
 function ec2_instance_credentials()
-
-    @assert localhost_is_ec2()
 
     info  = ec2_metadata("iam/info")
     info  = JSON.parse(info)

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -121,7 +121,7 @@ end
 
 function ec2_metadata(key)
 
-    http_request("169.254.169.254", "latest/meta-data/$key").data
+    bytestring(http_request("169.254.169.254", "latest/meta-data/$key").data)
 end
 
 
@@ -136,7 +136,7 @@ function ec2_instance_credentials()
 
     name  = ec2_metadata("iam/security-credentials/")
     creds = ec2_metadata("iam/security-credentials/$name")
-    creds = JSON.parse(new_creds)
+    new_creds = JSON.parse(creds)
 
     AWSCredentials(new_creds["AccessKeyId"],
                    new_creds["SecretAccessKey"],

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -120,6 +120,8 @@ end
 
 function ec2_metadata(key)
 
+    @assert localhost_is_ec2()
+    
     bytestring(http_request("169.254.169.254", "latest/meta-data/$key").data)
 end
 
@@ -130,6 +132,8 @@ using JSON
 
 function ec2_instance_credentials()
 
+    @assert localhost_is_ec2()
+    
     info  = ec2_metadata("iam/info")
     info  = JSON.parse(info)
 

--- a/src/http.jl
+++ b/src/http.jl
@@ -134,7 +134,7 @@ end
 function http_request(host::AbstractString, resource::AbstractString)
 
     http_request(Request("GET", resource,
-                         Dict{AbstractString,AbstractString}[], "",
+                         Dict{AbstractString,AbstractString}(), "",
                          URI("http://$host/$resource")))
 end
 


### PR DESCRIPTION
Small fixes that might relate to julia updates or trans-coding from OCAWS.
Tested on docker container running on EC2-VPC.