### PR TITLE
localhost_is_ec2 fix

### DIFF
--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -79,7 +79,7 @@ function localhost_is_ec2()
 
     @unix_only begin
         return isfile("/sys/hypervisor/uuid") &&
-               readstring(`head -c 3 /sys/hypervisor/uuid`) == "ec2"
+               bytestring(readbytes("/sys/hypervisor/uuid",3)) == "ec2"
     end
 
     return false


### PR DESCRIPTION
Replace shell-out to `head` with julia builtins when checking if localhost is an ec2 instance. A unix libuv error occurs if many (many) shell-out to head are performed.