### PR TITLE
enable spaces in path names

### DIFF
--- a/src/AWSCore.jl
+++ b/src/AWSCore.jl
@@ -92,7 +92,7 @@ end
 # Convert AWSRequest dictionary into Requests.Request (Requests.jl)
 
 function Request(r::AWSRequest)
-    Request(r[:verb], r[:resource], r[:headers], r[:content], URI(r[:url]))
+    Request(r[:verb], replace(r[:resource], " ", "+"), r[:headers], r[:content], URI(replace(r[:url], " ", "+")))
 end
 
 
@@ -145,7 +145,7 @@ function do_request(r::AWSRequest)
             r[:headers] = Dict()
         end
         r[:headers]["User-Agent"] = "JuliaAWS.jl/0.0.0"
-        r[:headers]["Host"]       = URI(r[:url]).host
+        r[:headers]["Host"]       = URI(replace(r[:url], " ", "+")).host
 
         # Load local system credentials if needed...
         if !haskey(r, :creds) || r[:creds].token == "ExpiredToken"

--- a/src/sign.jl
+++ b/src/sign.jl
@@ -36,8 +36,8 @@ function sign_aws2!(r::AWSRequest, t)
         (n, v) = split(elem, "=")
         query[n] = unescape(v)
     end
-    
-    r[:headers]["Content-Type"] = 
+
+    r[:headers]["Content-Type"] =
         "application/x-www-form-urlencoded; charset=utf-8"
 
     query["AWSAccessKeyId"] = r[:creds].access_key_id
@@ -54,15 +54,15 @@ function sign_aws2!(r::AWSRequest, t)
 #FIXME  see https://github.com/JuliaWeb/URIParser.jl/pull/31
 #    to_sign = "POST\n$(uri.host)\n$(uri.path)\n$(format_query_str(query))"
     to_sign = "POST\n$(uri.host)\n$(uri.path)\n$(escape_with(format_query_str(query), "()"))"
-    
+
     secret = r[:creds].secret_key
     push!(query, ("Signature", digest("sha256", secret, to_sign)
                                |> base64encode |> strip))
 
     r[:content] = format_query_str(query)
 end
-    
-                                        
+
+
 
 # Create AWS3 Authentication Headers.
 # http://docs.aws.amazon.com/ses/latest/DeveloperGuide/query-interface-authentication.html
@@ -121,13 +121,13 @@ function sign_aws4!(r::AWSRequest, t)
     signed_headers = join(sort([lowercase(k) for k in keys(r[:headers])]), ";")
 
     # Sort Query String...
-    uri = URI(r[:url])
+    uri = URI(replace(r[:url], " ", "+"))
     query = query_params(uri)
     query = [(k, query[k]) for k in sort(collect(keys(query)))]
 
     # Create hash of canonical request...
     canonical_form = string(r[:verb], "\n",
-                            escape_with(uri.path, path_esc_chars), "\n",
+                            escape_with(replace(uri.path, "+", " "), path_esc_chars), "\n",
                             format_query_str(query), "\n",
                             join(sort(canonical_headers), "\n"), "\n\n",
                             signed_headers, "\n",
@@ -154,4 +154,3 @@ const path_esc_chars = filter(c->c!='/', URIParser.unescaped)
 #==============================================================================#
 # End of file.
 #==============================================================================#
-


### PR DESCRIPTION
This commit adds the ability to have spaces in the path names. This does not escape other special characters.. do we  want to support those? 

Tested with keys: 

`test_no_spaces`
`adir/bdir/test_no_spaces`
`test spaces`
`adir/bdir/test spaces`

The last two did not work without this changes. 

cc: @samoconnor 