### PR TITLE
delete reference to InvalidAction

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,7 +35,6 @@ try
     @test false
 catch e
     println(e)
-    @test isa(e, AWSCore.InvalidAction)
 end
 
 try


### PR DESCRIPTION
this appears nowhere else in the repo and is causing an UndefVarError on Travis